### PR TITLE
feat(blog): restyle qr-code-and-vcard-guide + footer link + remove internal notes

### DIFF
--- a/blog/address-qr-code-business-card/index.html
+++ b/blog/address-qr-code-business-card/index.html
@@ -57,12 +57,7 @@
       <p>When embedding the address qr code business card in email signatures or PDFs, export the PNG at a generous resolution and avoid stretching the square image.</p>
     
       <p>If your details change, create a new address qr code business card and replace the old asset wherever it lives to keep networking experiences consistent.</p>
-    
-    <section class="mt-8 p-4 rounded-lg bg-white shadow border">
-      <h2 class="text-xl font-semibold">Why this page</h2>
-      <p>This page targets the query: <strong>address qr code business card</strong>. It explains how to create and use vCard QR codes for that specific intent.</p>
-    </section>
-  </main>
+</main>
   <footer class="text-center text-sm text-gray-500 py-10">© 2025 vCard QR Code Generator</footer>
 </body>
 </html>

--- a/blog/business-card-qr-code-generator/index.html
+++ b/blog/business-card-qr-code-generator/index.html
@@ -57,12 +57,7 @@
       <p>When embedding the business card qr code generator in email signatures or PDFs, export the PNG at a generous resolution and avoid stretching the square image.</p>
     
       <p>If your details change, create a new business card qr code generator and replace the old asset wherever it lives to keep networking experiences consistent.</p>
-    
-    <section class="mt-8 p-4 rounded-lg bg-white shadow border">
-      <h2 class="text-xl font-semibold">Why this page</h2>
-      <p>This page targets the query: <strong>business card qr code generator</strong>. It explains how to create and use vCard QR codes for that specific intent.</p>
-    </section>
-  </main>
+</main>
   <footer class="text-center text-sm text-gray-500 py-10">© 2025 vCard QR Code Generator</footer>
 </body>
 </html>

--- a/blog/business-qr-code-contactless-card/index.html
+++ b/blog/business-qr-code-contactless-card/index.html
@@ -57,12 +57,7 @@
       <p>When embedding the business qr code contactless card in email signatures or PDFs, export the PNG at a generous resolution and avoid stretching the square image.</p>
     
       <p>If your details change, create a new business qr code contactless card and replace the old asset wherever it lives to keep networking experiences consistent.</p>
-    
-    <section class="mt-8 p-4 rounded-lg bg-white shadow border">
-      <h2 class="text-xl font-semibold">Why this page</h2>
-      <p>This page targets the query: <strong>business qr code contactless card</strong>. It explains how to create and use vCard QR codes for that specific intent.</p>
-    </section>
-  </main>
+</main>
   <footer class="text-center text-sm text-gray-500 py-10">© 2025 vCard QR Code Generator</footer>
 </body>
 </html>

--- a/blog/contact-qr-code-generator/index.html
+++ b/blog/contact-qr-code-generator/index.html
@@ -57,12 +57,7 @@
       <p>When embedding the contact qr code generator in email signatures or PDFs, export the PNG at a generous resolution and avoid stretching the square image.</p>
     
       <p>If your details change, create a new contact qr code generator and replace the old asset wherever it lives to keep networking experiences consistent.</p>
-    
-    <section class="mt-8 p-4 rounded-lg bg-white shadow border">
-      <h2 class="text-xl font-semibold">Why this page</h2>
-      <p>This page targets the query: <strong>contact qr code generator</strong>. It explains how to create and use vCard QR codes for that specific intent.</p>
-    </section>
-  </main>
+</main>
   <footer class="text-center text-sm text-gray-500 py-10">© 2025 vCard QR Code Generator</footer>
 </body>
 </html>

--- a/blog/contact-qr-code-printing-guide/index.html
+++ b/blog/contact-qr-code-printing-guide/index.html
@@ -57,12 +57,7 @@
       <p>When embedding the contact qr code printing guide in email signatures or PDFs, export the PNG at a generous resolution and avoid stretching the square image.</p>
     
       <p>If your details change, create a new contact qr code printing guide and replace the old asset wherever it lives to keep networking experiences consistent.</p>
-    
-    <section class="mt-8 p-4 rounded-lg bg-white shadow border">
-      <h2 class="text-xl font-semibold">Why this page</h2>
-      <p>This page targets the query: <strong>contact qr code printing guide</strong>. It explains how to create and use vCard QR codes for that specific intent.</p>
-    </section>
-  </main>
+</main>
   <footer class="text-center text-sm text-gray-500 py-10">© 2025 vCard QR Code Generator</footer>
 </body>
 </html>

--- a/blog/email-vcard-qr-code-generator/index.html
+++ b/blog/email-vcard-qr-code-generator/index.html
@@ -57,12 +57,7 @@
       <p>When embedding the email vcard qr code generator in email signatures or PDFs, export the PNG at a generous resolution and avoid stretching the square image.</p>
     
       <p>If your details change, create a new email vcard qr code generator and replace the old asset wherever it lives to keep networking experiences consistent.</p>
-    
-    <section class="mt-8 p-4 rounded-lg bg-white shadow border">
-      <h2 class="text-xl font-semibold">Why this page</h2>
-      <p>This page targets the query: <strong>email vcard qr code generator</strong>. It explains how to create and use vCard QR codes for that specific intent.</p>
-    </section>
-  </main>
+</main>
   <footer class="text-center text-sm text-gray-500 py-10">© 2025 vCard QR Code Generator</footer>
 </body>
 </html>

--- a/blog/phone-contact-qr-code-how-to/index.html
+++ b/blog/phone-contact-qr-code-how-to/index.html
@@ -57,12 +57,7 @@
       <p>When embedding the phone contact qr code how to in email signatures or PDFs, export the PNG at a generous resolution and avoid stretching the square image.</p>
     
       <p>If your details change, create a new phone contact qr code how to and replace the old asset wherever it lives to keep networking experiences consistent.</p>
-    
-    <section class="mt-8 p-4 rounded-lg bg-white shadow border">
-      <h2 class="text-xl font-semibold">Why this page</h2>
-      <p>This page targets the query: <strong>phone contact qr code how to</strong>. It explains how to create and use vCard QR codes for that specific intent.</p>
-    </section>
-  </main>
+</main>
   <footer class="text-center text-sm text-gray-500 py-10">© 2025 vCard QR Code Generator</footer>
 </body>
 </html>

--- a/blog/qr-code-and-vcard-guide/index.html
+++ b/blog/qr-code-and-vcard-guide/index.html
@@ -1,138 +1,111 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="The Complete Guide to vCard QR Codes: Everything You Need to Know. Discover benefits, how-to steps, business applications, troubleshooting, FAQs and more. Comprehensive resource!">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Complete Guide to vCard QR Codes: Everything You Need to Know</title>
-  <link rel="stylesheet" href="style.css">
-  <link rel="canonical" href="https://vcardqrcodegenerator.com/blog/qr-code-and-vcard-guide/">
+  <meta name="description" content="vCard QR codes are smart digital barcodes that instantly transform printed or digital media into contact-saving tools. When scanned, a vCard QR code lets users save your details." />
+  <link rel="canonical" href="https://vcardqrcodegenerator.com/blog/qr-code-and-vcard-guide/" />
+  <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body>
-  <nav class="guide-nav-container" aria-label="Main Navigation">
-    <div class="container flex justify-between items-center">
-      <a href="#" class="guide-logo" aria-label="vCard QR Home">vCard QR Guide</a>
-      <div class="guide-nav-links flex gap-8">
-        <a href="#generator" class="btn btn--primary btn--sm">Try QR Generator</a>
-        <a href="#contact" class="btn btn--outline btn--sm">Contact</a>
-      </div>
-    </div>
-  </nav>
-
-  <header class="guide-header">
-    <div class="container">
-      <h1 class="guide-title">The Complete Guide to vCard QR Codes: Everything You Need to Know</h1>
-      <p class="guide-intro">vCard QR codes are smart digital barcodes that instantly transform printed or digital media into contact-saving tools. When scanned, a vCard QR code lets users save your details to their phone address book with just one tap—no manual entry required. They're revolutionizing networking, professional branding, and digital information sharing for everyone from freelancers to corporate teams.</p>
+<body class="bg-slate-50 text-slate-900 antialiased">
+  <header class="bg-gradient-to-r from-indigo-600 via-sky-600 to-cyan-500 text-white">
+    <div class="max-w-4xl mx-auto px-6 py-12">
+      <a href="/" class="text-white/90 hover:text-white underline decoration-white/60">&larr; Home</a>
+      <h1 class="mt-6 text-3xl sm:text-4xl font-bold tracking-tight">The Complete Guide to vCard QR Codes: Everything You Need to Know</h1>
+      <p class="mt-4 text-lg leading-relaxed text-white/90">vCard QR codes are smart digital barcodes that instantly transform printed or digital media into contact-saving tools. When scanned, a vCard QR code lets users save your details to their phone address book with just one tap—no manual entry required. They're revolutionizing networking, professional branding, and digital information sharing for everyone from freelancers to corporate teams.</p>
     </div>
   </header>
 
-  <div class="guide-toc-section">
-    <div class="container">
-      <nav class="guide-toc" aria-label="Table of Contents">
-        <h2 class="guide-toc-title">Table of Contents</h2>
-        <ol>
-          <li><a href="#what-are-vcard-qr-codes">What are vCard QR Codes?</a></li>
-          <li><a href="#how-vcard-qr-codes-work">How vCard QR Codes Work</a></li>
-          <li><a href="#comparison">vCard QR Codes vs Traditional QR Codes</a></li>
-          <li><a href="#types">Types of QR Codes for Business</a></li>
-          <li><a href="#benefits">Benefits of vCard QR Codes</a></li>
-          <li><a href="#create">How to Create a vCard QR Code (6 Steps)</a></li>
-          <li><a href="#best-practices">Best Practices</a></li>
-          <li><a href="#applications">Business Applications</a></li>
-          <li><a href="#troubleshooting">Troubleshooting</a></li>
-          <li><a href="#faq">FAQ</a></li>
+  <main class="max-w-4xl mx-auto px-6 py-12">
+    <div class="space-y-12 text-lg leading-relaxed text-slate-700">
+      <nav class="rounded-2xl border border-slate-200 bg-white/80 shadow-sm backdrop-blur-sm p-6" aria-label="Table of Contents">
+        <h2 class="text-2xl font-semibold text-slate-900">Table of Contents</h2>
+        <ol class="mt-4 list-decimal list-inside space-y-2 text-base sm:text-lg">
+          <li><a href="#what-are-vcard-qr-codes" class="text-indigo-600 hover:text-indigo-500">What are vCard QR Codes?</a></li>
+          <li><a href="#how-vcard-qr-codes-work" class="text-indigo-600 hover:text-indigo-500">How vCard QR Codes Work</a></li>
+          <li><a href="#comparison" class="text-indigo-600 hover:text-indigo-500">vCard QR Codes vs Traditional QR Codes</a></li>
+          <li><a href="#types" class="text-indigo-600 hover:text-indigo-500">Types of QR Codes for Business</a></li>
+          <li><a href="#benefits" class="text-indigo-600 hover:text-indigo-500">Benefits of vCard QR Codes</a></li>
+          <li><a href="#create" class="text-indigo-600 hover:text-indigo-500">How to Create a vCard QR Code (6 Steps)</a></li>
+          <li><a href="#best-practices" class="text-indigo-600 hover:text-indigo-500">Best Practices</a></li>
+          <li><a href="#applications" class="text-indigo-600 hover:text-indigo-500">Business Applications</a></li>
+          <li><a href="#troubleshooting" class="text-indigo-600 hover:text-indigo-500">Troubleshooting</a></li>
+          <li><a href="#faq" class="text-indigo-600 hover:text-indigo-500">FAQ</a></li>
         </ol>
       </nav>
-    </div>
-  </div>
 
-  <aside class="cta-box-container" id="generator">
-    <div class="container">
-      <div class="card cta-box">
-        <div class="card__body">
-          <h3>Ready to create your vCard QR code?</h3>
+      <section class="rounded-2xl border border-slate-200 bg-white shadow-sm p-6" id="generator">
+        <div class="space-y-4">
+          <h3 class="text-xl font-semibold text-slate-900">Ready to create your vCard QR code?</h3>
           <p>Generate a professional, instant digital business card with our <strong>free vCard QR generator</strong>. Fast, secure, unlimited!</p>
-          <a href="#" class="btn btn--primary btn--lg">Try the QR Generator</a>
+          <a href="#" class="inline-flex items-center justify-center rounded-full bg-indigo-600 px-5 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-indigo-500">Try the QR Generator</a>
         </div>
-      </div>
-    </div>
-  </aside>
+      </section>
 
-  <main id="main-guide-content">
-    <section id="what-are-vcard-qr-codes" class="guide-section">
-      <div class="container">
-        <h2>What are vCard QR Codes?</h2>
+      <section id="what-are-vcard-qr-codes" class="space-y-4">
+        <h2 class="text-2xl font-semibold text-slate-900">What are vCard QR Codes?</h2>
         <p>A vCard QR code is a specialized QR code that contains digital contact information in vCard format. When scanned, it automatically prompts users to save the contact details directly to their phone's address book without manual typing.</p>
-      </div>
-    </section>
+      </section>
 
-    <aside class="cta-box-container">
-      <div class="container">
-        <div class="card cta-box">
-          <div class="card__body">
-            <h3>Instant Networking</h3>
-            <p>Upgrade your business cards and marketing materials—<strong>no more tedious data entry</strong>. Generate your QR code in seconds!</p>
-            <a href="#" class="btn btn--primary btn--lg">Create your QR Code</a>
-          </div>
+      <section class="rounded-2xl border border-slate-200 bg-white shadow-sm p-6">
+        <div class="space-y-4">
+          <h3 class="text-xl font-semibold text-slate-900">Instant Networking</h3>
+          <p>Upgrade your business cards and marketing materials—<strong>no more tedious data entry</strong>. Generate your QR code in seconds!</p>
+          <a href="#" class="inline-flex items-center justify-center rounded-full bg-indigo-600 px-5 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-indigo-500">Create your QR Code</a>
         </div>
-      </div>
-    </aside>
+      </section>
 
-    <section id="how-vcard-qr-codes-work" class="guide-section">
-      <div class="container">
-        <h2>How vCard QR Codes Work</h2>
-        <ol class="steps-list">
+      <section id="how-vcard-qr-codes-work" class="space-y-4">
+        <h2 class="text-2xl font-semibold text-slate-900">How vCard QR Codes Work</h2>
+        <ol class="list-decimal list-inside space-y-2">
           <li><strong>Scanning:</strong> The phone's camera reads the QR code pattern</li>
           <li><strong>Decoding:</strong> The device decodes the vCard format embedded in the code</li>
           <li><strong>Preview:</strong> Contact details appear on screen for review</li>
           <li><strong>Saving:</strong> User taps 'Add to Contacts' to save information instantly</li>
         </ol>
-      </div>
-    </section>
+      </section>
 
-    <section id="comparison" class="guide-section">
-      <div class="container">
-        <h2>vCard QR Codes vs Traditional QR Codes</h2>
-        <div class="comparison-table-wrapper">
-          <table class="comparison-table">
-            <thead>
+      <section id="comparison" class="space-y-4">
+        <h2 class="text-2xl font-semibold text-slate-900">vCard QR Codes vs Traditional QR Codes</h2>
+        <div class="overflow-x-auto rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <table class="min-w-full divide-y divide-slate-200 text-left text-base">
+            <thead class="bg-slate-100 text-slate-900">
               <tr>
-                <th>Feature</th>
-                <th>vCard QR Code</th>
-                <th>Traditional QR Code</th>
+                <th class="px-4 py-3 font-semibold">Feature</th>
+                <th class="px-4 py-3 font-semibold">vCard QR Code</th>
+                <th class="px-4 py-3 font-semibold">Traditional QR Code</th>
               </tr>
             </thead>
-            <tbody>
+            <tbody class="divide-y divide-slate-200">
               <tr>
-                <td>Purpose</td>
-                <td>Share contact information</td>
-                <td>Various (URLs, text, etc.)</td>
+                <td class="px-4 py-3">Purpose</td>
+                <td class="px-4 py-3">Share contact information</td>
+                <td class="px-4 py-3">Various (URLs, text, etc.)</td>
               </tr>
               <tr>
-                <td>Main Action</td>
-                <td>Add contact directly</td>
-                <td>Open browser or app</td>
+                <td class="px-4 py-3">Main Action</td>
+                <td class="px-4 py-3">Add contact directly</td>
+                <td class="px-4 py-3">Open browser or app</td>
               </tr>
               <tr>
-                <td>Storage</td>
-                <td>Structured contact data</td>
-                <td>Plain text or URL</td>
+                <td class="px-4 py-3">Storage</td>
+                <td class="px-4 py-3">Structured contact data</td>
+                <td class="px-4 py-3">Plain text or URL</td>
               </tr>
               <tr>
-                <td>Offline Functionality</td>
-                <td>Works without internet</td>
-                <td>May require internet</td>
+                <td class="px-4 py-3">Offline Functionality</td>
+                <td class="px-4 py-3">Works without internet</td>
+                <td class="px-4 py-3">May require internet</td>
               </tr>
             </tbody>
           </table>
         </div>
-      </div>
-    </section>
+      </section>
 
-    <section id="types" class="guide-section">
-      <div class="container">
-        <h2>Types of QR Codes for Business</h2>
-        <ul>
+      <section id="types" class="space-y-4">
+        <h2 class="text-2xl font-semibold text-slate-900">Types of QR Codes for Business</h2>
+        <ul class="list-disc list-inside space-y-2">
           <li>vCard QR Codes: Digital business card/contact sharing</li>
           <li>URL QR Codes: Website links, portfolios, appointment booking</li>
           <li>Email QR Codes: Pre-filled email composition to contact instantly</li>
@@ -140,13 +113,11 @@
           <li>Event QR Codes: Calendar invites with date/time/location details</li>
           <li>Text QR Codes: Short messages, promotional codes, instructions</li>
         </ul>
-      </div>
-    </section>
+      </section>
 
-    <section id="benefits" class="guide-section">
-      <div class="container">
-        <h2>Benefits of vCard QR Codes</h2>
-        <ul class="benefits-list">
+      <section id="benefits" class="space-y-4">
+        <h2 class="text-2xl font-semibold text-slate-900">Benefits of vCard QR Codes</h2>
+        <ul class="list-disc list-inside space-y-2">
           <li>Instant contact sharing eliminates manual data entry</li>
           <li>Professional image demonstrates tech-savviness</li>
           <li>Error-free contact information prevents typos</li>
@@ -154,25 +125,19 @@
           <li>Eco-friendly - Reduces paper waste</li>
           <li>Universal compatibility - Works on all smartphones</li>
         </ul>
-      </div>
-    </section>
+      </section>
 
-    <aside class="cta-box-container">
-      <div class="container">
-        <div class="card cta-box">
-          <div class="card__body">
-            <h3>Start using vCard QR codes today!</h3>
-            <p>Make smart connections and <strong>stand out as a tech-savvy professional</strong> in any field.</p>
-            <a href="#" class="btn btn--primary btn--lg">Try the QR Generator</a>
-          </div>
+      <section class="rounded-2xl border border-slate-200 bg-white shadow-sm p-6">
+        <div class="space-y-4">
+          <h3 class="text-xl font-semibold text-slate-900">Start using vCard QR codes today!</h3>
+          <p>Make smart connections and <strong>stand out as a tech-savvy professional</strong> in any field.</p>
+          <a href="#" class="inline-flex items-center justify-center rounded-full bg-indigo-600 px-5 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-indigo-500">Try the QR Generator</a>
         </div>
-      </div>
-    </aside>
+      </section>
 
-    <section id="create" class="guide-section">
-      <div class="container">
-        <h2>How to Create a vCard QR Code (6 Steps)</h2>
-        <ol class="steps-list">
+      <section id="create" class="space-y-4">
+        <h2 class="text-2xl font-semibold text-slate-900">How to Create a vCard QR Code (6 Steps)</h2>
+        <ol class="list-decimal list-inside space-y-2">
           <li>Visit a trusted QR code generator</li>
           <li>Choose 'vCard' as your QR code type</li>
           <li>Enter your contact details (name, job title, company, phone, email)</li>
@@ -180,113 +145,83 @@
           <li>Preview and test scan before printing or sharing</li>
           <li>Download your QR code and use it on business cards, email signatures, and more</li>
         </ol>
-        <div class="info-note">
+        <div class="rounded-xl border border-slate-200 bg-slate-100/60 px-5 py-4 text-base text-slate-800">
           <strong>Tip:</strong> Always verify your contact info and test the QR code before distributing!
         </div>
-      </div>
-    </section>
+      </section>
 
-    <section id="best-practices" class="guide-section">
-      <div class="container">
-        <h2>Best Practices</h2>
-        <ul>
+      <section id="best-practices" class="space-y-4">
+        <h2 class="text-2xl font-semibold text-slate-900">Best Practices</h2>
+        <ul class="list-disc list-inside space-y-2">
           <li><strong>Design:</strong> Keep codes high-contrast, add brand colors and logo for recognition</li>
           <li><strong>Content:</strong> Include only the most relevant contact details</li>
           <li><strong>Placement:</strong> Position on business card front, email signature, event flyers</li>
           <li><strong>Testing:</strong> Always scan and verify info on multiple devices</li>
         </ul>
-      </div>
-    </section>
+      </section>
 
-    <section id="applications" class="guide-section">
-      <div class="container">
-        <h2>Business Applications</h2>
-        <ul>
+      <section id="applications" class="space-y-4">
+        <h2 class="text-2xl font-semibold text-slate-900">Business Applications</h2>
+        <ul class="list-disc list-inside space-y-2">
           <li>Networking events and conferences</li>
           <li>Printed business cards and brochures</li>
           <li>Email signatures for digital outreach</li>
           <li>Company website/contact page</li>
           <li>Marketing campaigns and trade shows</li>
         </ul>
-      </div>
-    </section>
+      </section>
 
-    <section id="troubleshooting" class="guide-section">
-      <div class="container">
-        <h2>Troubleshooting</h2>
-        <ul>
+      <section id="troubleshooting" class="space-y-4">
+        <h2 class="text-2xl font-semibold text-slate-900">Troubleshooting</h2>
+        <ul class="list-disc list-inside space-y-2">
           <li>QR code not scanning? Check print quality and code contrast</li>
           <li>Device not recognizing vCard? Ensure the code was created in vCard format</li>
           <li>Too much info? Limit contact details to what's essential</li>
           <li>Still having issues? Test on multiple phones and ask for feedback</li>
         </ul>
-      </div>
-    </section>
+      </section>
 
-    <section id="faq" class="guide-section">
-      <div class="container">
-        <h2>FAQ</h2>
-        <div class="faq-list">
-          <div class="faq-box card">
-            <div class="card__body">
-              <h3 class="faq-question">What's the difference between a QR code and vCard QR code?</h3>
-              <p class="faq-answer">A regular QR code can contain various types of data, while a vCard QR code specifically contains structured contact information in vCard format that phones recognize and can save directly to contacts.</p>
-            </div>
+      <section id="faq" class="space-y-6">
+        <h2 class="text-2xl font-semibold text-slate-900">FAQ</h2>
+        <div class="grid gap-6">
+          <div class="rounded-2xl border border-slate-200 bg-white shadow-sm p-6">
+            <h3 class="text-xl font-semibold text-slate-900">What's the difference between a QR code and vCard QR code?</h3>
+            <p>A regular QR code can contain various types of data, while a vCard QR code specifically contains structured contact information in vCard format that phones recognize and can save directly to contacts.</p>
           </div>
-          <div class="faq-box card">
-            <div class="card__body">
-              <h3 class="faq-question">Do I need a special app to scan vCard QR codes?</h3>
-              <p class="faq-answer">No, most modern smartphones can scan vCard QR codes using their built-in camera app. The phone will automatically recognize the vCard format and prompt to save the contact.</p>
-            </div>
+          <div class="rounded-2xl border border-slate-200 bg-white shadow-sm p-6">
+            <h3 class="text-xl font-semibold text-slate-900">Do I need a special app to scan vCard QR codes?</h3>
+            <p>No, most modern smartphones can scan vCard QR codes using their built-in camera app. The phone will automatically recognize the vCard format and prompt to save the contact.</p>
           </div>
-          <div class="faq-box card">
-            <div class="card__body">
-              <h3 class="faq-question">How much information can a vCard QR code store?</h3>
-              <p class="faq-answer">A vCard QR code can store name, multiple phone numbers, email addresses, company information, website URLs, and physical addresses. However, too much information can make the QR code complex and harder to scan.</p>
-            </div>
+          <div class="rounded-2xl border border-slate-200 bg-white shadow-sm p-6">
+            <h3 class="text-xl font-semibold text-slate-900">How much information can a vCard QR code store?</h3>
+            <p>A vCard QR code can store name, multiple phone numbers, email addresses, company information, website URLs, and physical addresses. However, too much information can make the QR code complex and harder to scan.</p>
           </div>
-          <div class="faq-box card">
-            <div class="card__body">
-              <h3 class="faq-question">What if my vCard QR code won't scan?</h3>
-              <p class="faq-answer">Make sure the QR code is printed clearly and not distorted. Use sufficient contrast and test on several devices before sharing widely.</p>
-            </div>
+          <div class="rounded-2xl border border-slate-200 bg-white shadow-sm p-6">
+            <h3 class="text-xl font-semibold text-slate-900">What if my vCard QR code won't scan?</h3>
+            <p>Make sure the QR code is printed clearly and not distorted. Use sufficient contrast and test on several devices before sharing widely.</p>
           </div>
-          <div class="faq-box card">
-            <div class="card__body">
-              <h3 class="faq-question">Can I update my contact info after making a vCard QR code?</h3>
-              <p class="faq-answer">No, static vCard QR codes can't be updated once printed. For updatable info, consider dynamic QR solutions, but most business card use cases are static.</p>
-            </div>
+          <div class="rounded-2xl border border-slate-200 bg-white shadow-sm p-6">
+            <h3 class="text-xl font-semibold text-slate-900">Can I update my contact info after making a vCard QR code?</h3>
+            <p>No, static vCard QR codes can't be updated once printed. For updatable info, consider dynamic QR solutions, but most business card use cases are static.</p>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+
+      <section class="rounded-2xl border border-slate-200 bg-white shadow-sm p-6">
+        <div class="space-y-4">
+          <h3 class="text-xl font-semibold text-slate-900">Get Started</h3>
+          <p>Ready to make smarter connections? <a href="#" class="font-semibold text-indigo-600 hover:text-indigo-500">Start with our QR generator</a> now!</p>
+          <a href="#" class="inline-flex items-center justify-center rounded-full bg-indigo-600 px-5 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-indigo-500">Try QR Generator</a>
+        </div>
+      </section>
+    </div>
   </main>
 
-  <aside class="cta-box-container">
-    <div class="container">
-      <div class="card cta-box">
-        <div class="card__body">
-          <h3>Get Started</h3>
-          <p>Ready to make smarter connections? <a href="#" class="guide-link">Start with our QR generator</a> now!</p>
-          <a href="#" class="btn btn--primary btn--lg">Try QR Generator</a>
-        </div>
-      </div>
-    </div>
-  </aside>
-
-  <footer class="guide-footer" id="contact">
-    <div class="container flex justify-between items-center">
-      <div class="guide-footer-info">
-        <span class="footer-logo">vCard QR Guide</span>
-        <span>&copy; 2025 All rights reserved.</span>
-      </div>
-      <div class="guide-footer-links flex gap-8">
-        <a href="#generator" class="footer-link">QR Generator</a>
-        <a href="#faq" class="footer-link">FAQ</a>
-        <a href="#" class="footer-link" target="_blank">Contact</a>
-      </div>
+  <footer class="border-t border-slate-200 bg-white/90 py-10">
+    <div class="max-w-4xl mx-auto px-6 flex flex-col items-center gap-2 text-sm text-slate-500">
+      <span class="font-semibold text-slate-700">vCard QR Guide</span>
+      <span>&copy; 2025 All rights reserved.</span>
     </div>
   </footer>
-  <script src="app.js"></script>
 </body>
 </html>

--- a/blog/qr-code-business-contact-tips/index.html
+++ b/blog/qr-code-business-contact-tips/index.html
@@ -57,12 +57,7 @@
       <p>When embedding the qr code business contact tips in email signatures or PDFs, export the PNG at a generous resolution and avoid stretching the square image.</p>
     
       <p>If your details change, create a new qr code business contact tips and replace the old asset wherever it lives to keep networking experiences consistent.</p>
-    
-    <section class="mt-8 p-4 rounded-lg bg-white shadow border">
-      <h2 class="text-xl font-semibold">Why this page</h2>
-      <p>This page targets the query: <strong>qr code business contact tips</strong>. It explains how to create and use vCard QR codes for that specific intent.</p>
-    </section>
-  </main>
+</main>
   <footer class="text-center text-sm text-gray-500 py-10">© 2025 vCard QR Code Generator</footer>
 </body>
 </html>

--- a/blog/qr-code-contact-card/index.html
+++ b/blog/qr-code-contact-card/index.html
@@ -57,12 +57,7 @@
       <p>When embedding the qr code contact card in email signatures or PDFs, export the PNG at a generous resolution and avoid stretching the square image.</p>
     
       <p>If your details change, create a new qr code contact card and replace the old asset wherever it lives to keep networking experiences consistent.</p>
-    
-    <section class="mt-8 p-4 rounded-lg bg-white shadow border">
-      <h2 class="text-xl font-semibold">Why this page</h2>
-      <p>This page targets the query: <strong>qr code contact card</strong>. It explains how to create and use vCard QR codes for that specific intent.</p>
-    </section>
-  </main>
+</main>
   <footer class="text-center text-sm text-gray-500 py-10">© 2025 vCard QR Code Generator</footer>
 </body>
 </html>

--- a/blog/qr-code-vcf-contact-file/index.html
+++ b/blog/qr-code-vcf-contact-file/index.html
@@ -57,12 +57,7 @@
       <p>When embedding the qr code vcf contact file in email signatures or PDFs, export the PNG at a generous resolution and avoid stretching the square image.</p>
     
       <p>If your details change, create a new qr code vcf contact file and replace the old asset wherever it lives to keep networking experiences consistent.</p>
-    
-    <section class="mt-8 p-4 rounded-lg bg-white shadow border">
-      <h2 class="text-xl font-semibold">Why this page</h2>
-      <p>This page targets the query: <strong>qr code vcf contact file</strong>. It explains how to create and use vCard QR codes for that specific intent.</p>
-    </section>
-  </main>
+</main>
   <footer class="text-center text-sm text-gray-500 py-10">© 2025 vCard QR Code Generator</footer>
 </body>
 </html>

--- a/blog/qr-vcard-for-networking-events/index.html
+++ b/blog/qr-vcard-for-networking-events/index.html
@@ -57,12 +57,7 @@
       <p>When embedding the qr vcard for networking events in email signatures or PDFs, export the PNG at a generous resolution and avoid stretching the square image.</p>
     
       <p>If your details change, create a new qr vcard for networking events and replace the old asset wherever it lives to keep networking experiences consistent.</p>
-    
-    <section class="mt-8 p-4 rounded-lg bg-white shadow border">
-      <h2 class="text-xl font-semibold">Why this page</h2>
-      <p>This page targets the query: <strong>qr vcard for networking events</strong>. It explains how to create and use vCard QR codes for that specific intent.</p>
-    </section>
-  </main>
+</main>
   <footer class="text-center text-sm text-gray-500 py-10">© 2025 vCard QR Code Generator</footer>
 </body>
 </html>

--- a/blog/vcard-qr-code-best-practices/index.html
+++ b/blog/vcard-qr-code-best-practices/index.html
@@ -57,12 +57,7 @@
       <p>When embedding the vcard qr code best practices in email signatures or PDFs, export the PNG at a generous resolution and avoid stretching the square image.</p>
     
       <p>If your details change, create a new vcard qr code best practices and replace the old asset wherever it lives to keep networking experiences consistent.</p>
-    
-    <section class="mt-8 p-4 rounded-lg bg-white shadow border">
-      <h2 class="text-xl font-semibold">Why this page</h2>
-      <p>This page targets the query: <strong>vcard qr code best practices</strong>. It explains how to create and use vCard QR codes for that specific intent.</p>
-    </section>
-  </main>
+</main>
   <footer class="text-center text-sm text-gray-500 py-10">© 2025 vCard QR Code Generator</footer>
 </body>
 </html>

--- a/blog/vcard-qr-code-download-guide/index.html
+++ b/blog/vcard-qr-code-download-guide/index.html
@@ -57,12 +57,7 @@
       <p>When embedding the vcard qr code download guide in email signatures or PDFs, export the PNG at a generous resolution and avoid stretching the square image.</p>
     
       <p>If your details change, create a new vcard qr code download guide and replace the old asset wherever it lives to keep networking experiences consistent.</p>
-    
-    <section class="mt-8 p-4 rounded-lg bg-white shadow border">
-      <h2 class="text-xl font-semibold">Why this page</h2>
-      <p>This page targets the query: <strong>vcard qr code download guide</strong>. It explains how to create and use vCard QR codes for that specific intent.</p>
-    </section>
-  </main>
+</main>
   <footer class="text-center text-sm text-gray-500 py-10">© 2025 vCard QR Code Generator</footer>
 </body>
 </html>

--- a/blog/vcard-qr-code-generator/index.html
+++ b/blog/vcard-qr-code-generator/index.html
@@ -57,12 +57,7 @@
       <p>When embedding the vcard qr code generator in email signatures or PDFs, export the PNG at a generous resolution and avoid stretching the square image.</p>
     
       <p>If your details change, create a new vcard qr code generator and replace the old asset wherever it lives to keep networking experiences consistent.</p>
-    
-    <section class="mt-8 p-4 rounded-lg bg-white shadow border">
-      <h2 class="text-xl font-semibold">Why this page</h2>
-      <p>This page targets the query: <strong>vcard qr code generator</strong>. It explains how to create and use vCard QR codes for that specific intent.</p>
-    </section>
-  </main>
+</main>
   <footer class="text-center text-sm text-gray-500 py-10">© 2025 vCard QR Code Generator</footer>
 </body>
 </html>

--- a/blog/vcard-qr-code/index.html
+++ b/blog/vcard-qr-code/index.html
@@ -57,12 +57,7 @@
       <p>When embedding the vcard qr code in email signatures or PDFs, export the PNG at a generous resolution and avoid stretching the square image.</p>
     
       <p>If your details change, create a new vcard qr code and replace the old asset wherever it lives to keep networking experiences consistent.</p>
-    
-    <section class="mt-8 p-4 rounded-lg bg-white shadow border">
-      <h2 class="text-xl font-semibold">Why this page</h2>
-      <p>This page targets the query: <strong>vcard qr code</strong>. It explains how to create and use vCard QR codes for that specific intent.</p>
-    </section>
-  </main>
+</main>
   <footer class="text-center text-sm text-gray-500 py-10">© 2025 vCard QR Code Generator</footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -384,7 +384,7 @@
       <p style="margin-top: 15px;">
         <a href="privacy-policy.html" style="color: #9ca3af; text-decoration: none; margin: 0 15px;">Privacy Policy</a>
         <a href="contact.html" style="color: #9ca3af; text-decoration: none; margin: 0 15px;">Contact</a>
-        <a id="footer-how-to-link" href="/blog/vcard-qr-code-generator/" style="color: #9ca3af; text-decoration: none; margin: 0 15px;">How to Use</a>
+        <a id="footer-how-to-link" href="/blog/qr-code-and-vcard-guide/" style="color: #9ca3af; text-decoration: none; margin: 0 15px;">Ultimate vCard QR code guide</a>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Restyles /blog/qr-code-and-vcard-guide/ to match house layout (containers, typography, header/footer).
- Updates home page footer link text to Ultimate vCard QR code guide and points it to /blog/qr-code-and-vcard-guide/.
- Removes internal editor/SEO notes (“Why this page” sections, “This page targets the query…”) from all blog posts.

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d00b842f5c832e8dce2ddfb98f8310