### PR TITLE
chore: fix sitemap regression by scanning blog/ and blogs/ + refresh on push

### DIFF
--- a/.github/workflows/pseo.yml
+++ b/.github/workflows/pseo.yml
@@ -1,6 +1,8 @@
 name: pSEO Pages
 
 on:
+  push:
+    branches: [ main ]
   workflow_dispatch:
   schedule:
     - cron: "0 18 * * *"    # 18:00 UTC == 23:30 IST daily
@@ -27,14 +29,16 @@ jobs:
           PSEO_EPS: "0.6"
           PSEO_MIN_SAMPLES: "2"
           PSEO_DRY_RUN: "0"
-      - name: Generate sitemap & robots
+      - name: Generate sitemap, robots, manifest
         run: python scripts/pseo/update_sitemap.py
       - name: Commit and push if changed
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if ! git diff --quiet; then
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add -A
-            git commit -m "chore(pseo): generate blog pages [skip ci]"
+            git commit -m "chore(site-indexes): refresh sitemap/robots/manifest [skip ci]"
             git push
+          else
+            echo "No changes to commit."
           fi

--- a/scripts/pseo/update_sitemap.py
+++ b/scripts/pseo/update_sitemap.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
-import json, subprocess
+import json, re, subprocess
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Dict, Iterable, List, Optional
 from xml.etree.ElementTree import Element, SubElement, tostring
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -10,12 +12,36 @@ MANIFEST = ROOT / "blog_index.json"
 SITEMAP = ROOT / "sitemap.xml"
 ROBOTS  = ROOT / "robots.txt"
 
-def git_lastmod(path_rel: str) -> str:
+BLOG_DIRS = ["blog", "blogs"]  # scan both roots
+
+TITLE_RE = re.compile(r"<title>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+META_DESC_RE = re.compile(
+    r"<meta\s+[^>]*name=[\"']description[\"'][^>]*content=[\"'](.*?)[\"']",
+    re.IGNORECASE | re.DOTALL,
+)
+
+@dataclass
+class Post:
+    slug: str
+    url: str
+    title: str
+    description: str
+    date: str  # ISO date (YYYY-MM-DD)
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "slug": self.slug,
+            "title": self.title,
+            "description": self.description,
+            "url": self.url,
+            "date": self.date,
+        }
+
+def _git_last_commit_iso(path: Path) -> str:
     try:
         iso = subprocess.check_output(
-            ["git", "log", "-1", "--format=%cI", "--", path_rel],
-            cwd=ROOT,
-            text=True
+            ["git", "log", "-1", "--format=%cI", "--", str(path.relative_to(ROOT))],
+            cwd=ROOT, text=True
         ).strip()
         if iso:
             return iso
@@ -23,41 +49,106 @@ def git_lastmod(path_rel: str) -> str:
         pass
     return datetime.now(timezone.utc).isoformat()
 
-def add_url(parent: Element, loc: str, lastmod_iso: str):
-    u = SubElement(parent, "url")
-    SubElement(u, "loc").text = loc
-    SubElement(u, "lastmod").text = lastmod_iso
+def _parse_html_meta(html: str) -> Dict[str, str]:
+    title_match = TITLE_RE.search(html)
+    desc_match = META_DESC_RE.search(html)
+    title = (title_match.group(1).strip() if title_match else "Untitled")
+    description = (desc_match.group(1).strip() if desc_match else "")
+    return {"title": title, "description": description}
 
-def main():
+def _load_manifest() -> Dict[str, Dict[str, str]]:
+    if not MANIFEST.exists():
+        return {}
+    try:
+        data = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    out = {}
+    if isinstance(data, list):
+        for row in data:
+            if isinstance(row, dict) and "slug" in row:
+                out[row["slug"]] = row
+    return out
+
+def _discover_posts() -> List[Post]:
+    existing = _load_manifest()
+    posts: List[Post] = []
+    for root_name in BLOG_DIRS:
+        root = ROOT / root_name
+        if not root.exists():
+            continue
+        for idx in sorted(root.glob("*/index.html")):
+            slug = idx.parent.name
+            # URL namespace matches the directory root
+            url = f"/{root_name}/{slug}/"
+            try:
+                html = idx.read_text(encoding="utf-8")
+            except Exception:
+                html = ""
+            meta = _parse_html_meta(html)
+            prev = existing.get(slug, {})
+            # Preserve existing date when possible; else derive from git commit date
+            prev_date = prev.get("date", "")
+            if prev_date:
+                date_iso = prev_date[:10]
+            else:
+                commit_iso = _git_last_commit_iso(idx)
+                date_iso = commit_iso[:10]
+            posts.append(
+                Post(
+                    slug=slug,
+                    url=url,
+                    title=meta["title"] or prev.get("title") or slug.replace("-", " ").title(),
+                    description=meta["description"] or prev.get("description", ""),
+                    date=date_iso,
+                )
+            )
+    # Sort newest first by date
+    posts.sort(key=lambda p: p.date, reverse=True)
+    return posts
+
+def _write_manifest(posts: Iterable[Post]) -> None:
+    MANIFEST.write_text(
+        json.dumps([p.to_dict() for p in posts], indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+def _add_url(urlset: Element, loc: str, lastmod_iso: str):
+    el = SubElement(urlset, "url")
+    SubElement(el, "loc").text = loc
+    SubElement(el, "lastmod").text = lastmod_iso
+
+def _write_sitemap(posts: List[Post]) -> None:
     urlset = Element("urlset")
     urlset.set("xmlns", "http://www.sitemaps.org/schemas/sitemap/0.9")
 
     # Core pages (derive lastmod from git)
     core = [
-        (f"{SITE}/", "index.html"),
-        (f"{SITE}/privacy-policy.html", "privacy-policy.html"),
-        (f"{SITE}/contact.html", "contact.html"),
-        (f"{SITE}/blogs/", "blogs/index.html"),
+        (f"{SITE}/", ROOT / "index.html"),
+        (f"{SITE}/privacy-policy.html", ROOT / "privacy-policy.html"),
+        (f"{SITE}/contact.html", ROOT / "contact.html"),
     ]
-    for loc, rel in core:
-        add_url(urlset, loc, git_lastmod(rel))
+    # Include /blogs/ if it exists
+    blogs_index = ROOT / "blogs" / "index.html"
+    if blogs_index.exists():
+        core.append((f"{SITE}/blogs/", blogs_index))
 
-    # Blog posts (from manifest)
-    posts = []
-    if MANIFEST.exists():
-        posts = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    for loc, path in core:
+        _add_url(urlset, loc, _git_last_commit_iso(path))
+
+    # Blog posts
     for p in posts:
-        loc = f"{SITE}{p['url']}" if not p['url'].startswith("http") else p['url']
-        lastmod = p.get("date") or datetime.now(timezone.utc).date().isoformat()
-        # normalize to full datetime
-        if len(lastmod) == 10:  # YYYY-MM-DD
-            lastmod = f"{lastmod}T00:00:00+00:00"
-        add_url(urlset, loc, lastmod)
+        # lastmod as full ISO datetime based on git of that index.html
+        idx = ROOT / p.url.strip("/").split("/")[0] / p.slug / "index.html"
+        lastmod = _git_last_commit_iso(idx)
+        _add_url(urlset, f"{SITE}{p.url}", lastmod)
 
-    xml = '<?xml version="1.0" encoding="UTF-8"?>\n' + tostring(urlset, encoding="unicode")
+    xml = "<!-- GENERATED: do not edit by hand -->\n" + \
+          '<?xml version="1.0" encoding="UTF-8"?>\n' + \
+          tostring(urlset, encoding="unicode")
     SITEMAP.write_text(xml, encoding="utf-8")
 
-    # Ensure robots.txt advertises sitemap
+def _ensure_robots():
     line = f"Sitemap: {SITE}/sitemap.xml"
     if ROBOTS.exists():
         txt = ROBOTS.read_text(encoding="utf-8")
@@ -65,6 +156,12 @@ def main():
             ROBOTS.write_text((txt.rstrip() + "\n" + line + "\n"), encoding="utf-8")
     else:
         ROBOTS.write_text(line + "\n", encoding="utf-8")
+
+def main():
+    posts = _discover_posts()
+    _write_manifest(posts)
+    _write_sitemap(posts)
+    _ensure_robots()
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Replaces indexer to scan both blog/ and blogs/
- Rebuilds sitemap.xml, blog_index.json, updates robots.txt
- Runs on push to main; auto-commits generated files
- Adds “GENERATED” header to sitemap to avoid manual edits

------
https://chatgpt.com/codex/tasks/task_e_68d0289e4d68832eb945168cedc25610