### PR TITLE
feat: Dodo success page + Pro gate fix

### DIFF
--- a/logo-qr-code.html
+++ b/logo-qr-code.html
@@ -2,6 +2,10 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <style>
+      /* Hide Pro app until gate passes to avoid FOUC */
+      html:not(.pro-ok) body { visibility: hidden; }
+    </style>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Add Logo to QR Code - Professional vCard QR Generator</title>
     <meta name="description" content="Create a custom QR code with your logo. Our professional generator lets you easily add an image to your vCard QR code for a branded, unique look.">
@@ -18,6 +22,35 @@
     </style>
 </head>
 <body class="bg-gray-50 dark:bg-gray-900 text-gray-800 dark:text-gray-200">
+    <script>
+    // Gate access so only confirmed Pro sessions reach the uploader.
+    (function () {
+      try {
+        var params = new URLSearchParams(window.location.search);
+        var qsToken = params.get('access');          // Optional: allow single-use tokens if you ever need them
+        var EXPECTED = '';                           // Leave empty unless you want a specific token match
+
+        if (qsToken && (!EXPECTED || qsToken === EXPECTED)) {
+          sessionStorage.setItem('pro_token_ok', '1');
+          // Clean the URL to avoid leaking tokens
+          var clean = window.location.pathname + window.location.hash;
+          history.replaceState({}, '', clean);
+        }
+
+        var ok = sessionStorage.getItem('pro_token_ok') === '1';
+        if (ok) {
+          // Allow page to render
+          document.documentElement.classList.add('pro-ok');
+        } else {
+          // Not unlocked → send to purchase CTA on landing
+          window.location.replace('/#pro'); // if your CTA anchor differs, update it here
+        }
+      } catch (e) {
+        // On unexpected error, be safe and route to the public flow
+        window.location.replace('/#pro');
+      }
+    })();
+    </script>
 
     <div class="container mx-auto p-4 sm:p-6 lg:p-8">
         <div class="max-w-4xl mx-auto bg-white dark:bg-gray-800 p-6 sm:p-8 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700">

--- a/success.html
+++ b/success.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Thanks — Unlocking Pro…</title>
+  <meta name="robots" content="noindex" />
+  <style>
+    body {font-family: system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial, sans-serif; margin:0; padding:3rem; color:#111;}
+    .card {max-width:560px; margin:0 auto; border:1px solid #e5e7eb; border-radius:12px; padding:24px; box-shadow:0 10px 30px rgba(0,0,0,.06)}
+    h1 {font-size:1.5rem; margin:0 0 .5rem}
+    p {margin:.25rem 0}
+    .muted {color:#6b7280; font-size:.95rem}
+  </style>
+</head>
+<body>
+  <!-- Dodo payment success page re-applies the Pro unlock flow -->
+  <div class="card">
+    <h1>Payment complete ✅</h1>
+    <p>We’re unlocking Pro features for this browser.</p>
+    <p class="muted">You’ll be redirected in a moment…</p>
+  </div>
+
+  <script>
+    (function () {
+      try {
+        // Persist a short-lived “paid this session” flag for this browser.
+        sessionStorage.setItem('pro_token_ok', '1');
+
+        // Optional GA event (will no-op if gtag isn’t present)
+        if (typeof gtag === 'function') {
+          gtag('event', 'purchase_complete', { method: 'dodo' });
+        }
+      } catch (e) {}
+
+      // Clean URL (drop any query params) then go to Pro page
+      setTimeout(function () {
+        window.location.replace('/logo-qr-code.html');
+      }, 800);
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Dodo payment success page that stores a session flag and redirects to the Pro experience
- gate the logo-qr-code page behind the session flag or an optional access token while avoiding FOUC

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68f8c7c90cdc832eaa76970dd1196942