### PR TITLE
Add GitHub Actions workflow for Cloudflare Workers deployment

### DIFF
--- a/.github/workflows/deploy-workers.yml
+++ b/.github/workflows/deploy-workers.yml
@@ -1,0 +1,20 @@
+name: Deploy Cloudflare Workers
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Deploy Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- add deploy workflow triggered on pushes to main
- use Wrangler action to deploy Cloudflare Workers with repository secrets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe4ee354cc832e83ed8c981b32fd49