### PR TITLE
Fix Orank canonical host signals

### DIFF
--- a/data/agent-board.md
+++ b/data/agent-board.md
@@ -137,6 +137,7 @@ I am moving to a feature branch now. I will pause the SEO Autopilot first as req
 
 | Date | Agent | What Changed | Files Touched |
 |------|-------|-------------|---------------|
+| 2026-08-23 | Codex | Implemented clean Orank canonicalization correction on branch `codex/orank-canonical-www`: apex public paths route through the Worker and redirect permanently to matching `www` URLs, apex sitemap redirects to the preferred sitemap, robots advertises only the `www` sitemap, and the old apex-only agent homepage shell was removed while MCP/API/well-known handlers remain ahead of canonical redirects. Cleanup after merge/deploy verification. | `workers/router.js`, `wrangler.toml`, `robots.txt`, `sitemap.xml`, `data/agent-board.md` |
 | 2026-08-11 | Codex | Fixed Nick Launches badge detection for apex-domain scanners by adding the badge link/image and structured sameAs URL to the Worker-served apex homepage shell. | `workers/router.js`, `data/agent-board.md` |
 | 2026-08-11 | Codex | Added the Nick Launches featured badge to the homepage footer trust-badge area beside the existing Uneed badge and prepared it for live publication. | `index.html`, `data/agent-board.md` |
 | 2026-08-11 | Codex | Started task 1 from the six-item orank follow-up list: fixed the MCP handshake path by making `/.well-known/mcp` route POST JSON-RPC requests through the same handler as `/mcp`, while preserving GET discovery JSON. Branch purpose: MCP handshake remediation; cleanup after merge. | `workers/router.js`, `data/agent-board.md` |

--- a/robots.txt
+++ b/robots.txt
@@ -3,4 +3,3 @@ Allow: /
 
 Schemamap: https://www.vcardqrcodegenerator.com/.well-known/schema-feed.xml
 Sitemap: https://www.vcardqrcodegenerator.com/sitemap.xml
-Sitemap: https://vcardqrcodegenerator.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,475 +1,475 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://vcardqrcodegenerator.com/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/privacy-policy.html</loc>
+    <loc>https://www.vcardqrcodegenerator.com/privacy-policy.html</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/contact.html</loc>
+    <loc>https://www.vcardqrcodegenerator.com/contact.html</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/terms-of-service.html</loc>
+    <loc>https://www.vcardqrcodegenerator.com/terms-of-service.html</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/logo-qr-code.html</loc>
+    <loc>https://www.vcardqrcodegenerator.com/logo-qr-code.html</loc>
     <lastmod>2026-05-04T00:00:00+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/qr-code-with-logo.html</loc>
+    <loc>https://www.vcardqrcodegenerator.com/qr-code-with-logo.html</loc>
     <lastmod>2026-05-04T00:00:00+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/dynamic-qr-code-generator.html</loc>
+    <loc>https://www.vcardqrcodegenerator.com/dynamic-qr-code-generator.html</loc>
     <lastmod>2026-08-03T06:41:46+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/bulk-qr-code.html</loc>
+    <loc>https://www.vcardqrcodegenerator.com/bulk-qr-code.html</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blogs/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blogs/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/bulk-vcard-qr-codes-from-csv/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/bulk-vcard-qr-codes-from-csv/</loc>
     <lastmod>2026-07-27T00:00:00+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/generate-bulk-vcard-qr-codes-from-excel/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/generate-bulk-vcard-qr-codes-from-excel/</loc>
     <lastmod>2026-07-27T00:00:00+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/dynamic-qr-code-for-clinics/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/dynamic-qr-code-for-clinics/</loc>
     <lastmod>2026-06-10T07:50:46+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/dynamic-qr-code-for-salon/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/dynamic-qr-code-for-salon/</loc>
     <lastmod>2026-06-09T07:00:55+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/dynamic-qr-code-for-repair-business/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/dynamic-qr-code-for-repair-business/</loc>
     <lastmod>2026-06-08T08:25:47+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/dynamic-qr-code-for-service-business/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/dynamic-qr-code-for-service-business/</loc>
     <lastmod>2026-06-07T07:39:39+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/dynamic-qr-code-for-appointment-cards/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/dynamic-qr-code-for-appointment-cards/</loc>
     <lastmod>2026-06-06T00:00:00+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/dynamic-qr-code-for-real-estate-sign/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/dynamic-qr-code-for-real-estate-sign/</loc>
     <lastmod>2026-06-05T07:49:42+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/dynamic-qr-code-for-restaurant-menu/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/dynamic-qr-code-for-restaurant-menu/</loc>
     <lastmod>2026-06-04T08:03:57+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/dynamic-qr-code-for-local-business/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/dynamic-qr-code-for-local-business/</loc>
     <lastmod>2026-06-03T08:32:00+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/editable-qr-code-for-marketing-campaign/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/editable-qr-code-for-marketing-campaign/</loc>
     <lastmod>2026-06-02T08:11:29+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/dynamic-qr-code-for-small-business/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/dynamic-qr-code-for-small-business/</loc>
     <lastmod>2026-06-01T00:00:00+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-analytics/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-analytics/</loc>
     <lastmod>2026-05-27T07:46:18+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-for-product-packaging/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-for-product-packaging/</loc>
     <lastmod>2026-05-26T06:59:00+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/dynamic-qr-code-analytics/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/dynamic-qr-code-analytics/</loc>
     <lastmod>2026-05-25T08:01:33+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-for-trade-show-booth/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-for-trade-show-booth/</loc>
     <lastmod>2026-05-24T06:49:22+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-for-print-advertising/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-for-print-advertising/</loc>
     <lastmod>2026-05-23T06:21:52+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/business-card-qr-code-tracking/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/business-card-qr-code-tracking/</loc>
     <lastmod>2026-05-22T07:00:08+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/trackable-qr-code/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/trackable-qr-code/</loc>
     <lastmod>2026-05-21T07:04:28+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-lead-generation/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-lead-generation/</loc>
     <lastmod>2026-05-20T06:59:54+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/event-qr-code-tracking/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/event-qr-code-tracking/</loc>
     <lastmod>2026-05-19T06:59:47+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-campaign-tracking/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-campaign-tracking/</loc>
     <lastmod>2026-05-18T07:08:58+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-for-flyers/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-for-flyers/</loc>
     <lastmod>2026-05-17T06:33:14+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/dynamic-qr-code-for-business-cards/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/dynamic-qr-code-for-business-cards/</loc>
     <lastmod>2026-05-16T06:10:19+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-tracking-offline-marketing/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-tracking-offline-marketing/</loc>
     <lastmod>2026-05-15T18:07:40+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/reusable-qr-code/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/reusable-qr-code/</loc>
     <lastmod>2026-05-09T06:03:01+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/change-qr-code-after-printing/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/change-qr-code-after-printing/</loc>
     <lastmod>2026-05-08T05:38:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/dynamic-qr-code-generator/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/dynamic-qr-code-generator/</loc>
     <lastmod>2026-05-07T06:21:42+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/dynamic-vcard-qr-code/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/dynamic-vcard-qr-code/</loc>
     <lastmod>2026-05-06T06:16:11+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/editable-vcard-qr-code/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/editable-vcard-qr-code/</loc>
     <lastmod>2026-05-05T06:00:56+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/editable-qr-code/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/editable-qr-code/</loc>
     <lastmod>2026-05-04T17:15:31+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/what-qr-code-type-for-vcard-with-updates/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/what-qr-code-type-for-vcard-with-updates/</loc>
     <lastmod>2026-05-04T17:18:39+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/unitag-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/unitag-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/me-qr-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/me-qr-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/popl-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/popl-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qrcodechimp-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qrcodechimp-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/freeqrcode-fr-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/freeqrcode-fr-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qroq-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qroq-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/scantrust-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/scantrust-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/bitly-qr-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/bitly-qr-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-io-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-io-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qrcode-monkey-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qrcode-monkey-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/v1ce-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/v1ce-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/viralqr-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/viralqr-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/flowcode-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/flowcode-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/trueqrcode-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/trueqrcode-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/uniqode-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/uniqode-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/compzets-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/compzets-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/online-qr-code-image-generator-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/online-qr-code-image-generator-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/free-qr-code-generator-com-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/free-qr-code-generator-com-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-tiger-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-tiger-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/vcard-qr-code-format/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/vcard-qr-code-format/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/vcard-garden-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/vcard-garden-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qrvcards-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qrvcards-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/contact-et-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/contact-et-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-studio-pro-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-studio-pro-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qrcodefree-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qrcodefree-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/midiacode-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/midiacode-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-dive-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-dive-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/mini-qr-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/mini-qr-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/free-qr-code-generator-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/free-qr-code-generator-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/safercodes-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/safercodes-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/business-card-qr-code-generator/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/business-card-qr-code-generator/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-factory-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-factory-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qrfy-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qrfy-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-planet-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-planet-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-dynamic-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-dynamic-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/metriqr-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/metriqr-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-ai-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-ai-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/autonix-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/autonix-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/yohn-io-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/yohn-io-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/scanova-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/scanova-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/kaywa-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/kaywa-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-generator-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-generator-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/add-logo-to-qr-code/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/add-logo-to-qr-code/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-io-alternative/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-io-alternative/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/design-that-converts-vcard-qr-code/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/design-that-converts-vcard-qr-code/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/privacy-first-digital-business-card/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/privacy-first-digital-business-card/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/digital-networking-trends-2026/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/digital-networking-trends-2026/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/dynamic-vs-static-vcard-qr-codes/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/dynamic-vs-static-vcard-qr-codes/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/nfc-vs-qr-code-business-cards/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/nfc-vs-qr-code-business-cards/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-on-resume/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-on-resume/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/how-to-scan-vcard-qr-code-android-iphone/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/how-to-scan-vcard-qr-code-android-iphone/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/mecard-vs-vcard-qr-code/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/mecard-vs-vcard-qr-code/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/vcard-qr-code-vs-paper-business-cards/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/vcard-qr-code-vs-paper-business-cards/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/address-qr-code-business-card/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/address-qr-code-business-card/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/business-qr-code-contactless-card/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/business-qr-code-contactless-card/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/contact-qr-code-generator/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/contact-qr-code-generator/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/contact-qr-code-printing-guide/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/contact-qr-code-printing-guide/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/email-vcard-qr-code-generator/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/email-vcard-qr-code-generator/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/phone-contact-qr-code-how-to/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/phone-contact-qr-code-how-to/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-and-vcard-guide/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-and-vcard-guide/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-business-contact-tips/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-business-contact-tips/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-contact-card/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-contact-card/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-vcf-contact-file/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-vcf-contact-file/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-vcard-for-networking-events/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-vcard-for-networking-events/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/vcard-qr-code/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/vcard-qr-code/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/vcard-qr-code-best-practices/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/vcard-qr-code-best-practices/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/vcard-qr-code-download-guide/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/vcard-qr-code-download-guide/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/contact-management-workflows/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/contact-management-workflows/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/customize-qr-codes/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/customize-qr-codes/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/digital-business-card-strategies/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/digital-business-card-strategies/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/event-networking-playbook/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/event-networking-playbook/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-follow-up-ideas/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-follow-up-ideas/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-marketing-ideas/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-marketing-ideas/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/qr-code-networking-tips/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/qr-code-networking-tips/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/secure-qr-code-sharing/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/secure-qr-code-sharing/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/vcard-export-guide/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/vcard-export-guide/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
   <url>
-    <loc>https://vcardqrcodegenerator.com/blog/vcard-qr-code-generator/</loc>
+    <loc>https://www.vcardqrcodegenerator.com/blog/vcard-qr-code-generator/</loc>
     <lastmod>2026-05-03T18:40:37+00:00</lastmod>
   </url>
 </urlset>

--- a/workers/router.js
+++ b/workers/router.js
@@ -102,7 +102,6 @@ Allow: /
 
 Schemamap: ${SITE_URL}/.well-known/schema-feed.xml
 Sitemap: ${SITE_URL}/sitemap.xml
-Sitemap: ${BASE_URL}/sitemap.xml
 `;
 
 function notFound() {
@@ -166,6 +165,10 @@ function noTransform(response) {
     statusText: response.statusText,
     headers,
   });
+}
+
+function redirectToPreferredHost(url) {
+  return Response.redirect(`${SITE_URL}${url.pathname}${url.search}`, 301);
 }
 
 function apiError(code, message, status = 400, hint = 'See the developer docs for valid request formats.', extra = {}, extraHeaders = {}) {
@@ -351,73 +354,6 @@ function homepageStructuredData() {
       },
     ],
   };
-}
-
-function agentSafeHomepageHtml() {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>vCard QR Code Generator - Developer API, OpenAPI, MCP, and Free Contact QR Tool</title>
-  <meta name="description" content="Create free vCard QR codes and integrate with vCard QR Code Generator developer resources, OpenAPI, MCP tools, auth docs, webhooks, sandbox examples, and JSON API errors.">
-  <meta property="og:type" content="website">
-  <meta property="og:url" content="${SITE_URL}/">
-  <meta property="og:title" content="vCard QR Code Generator Developer API and Free Contact QR Tool">
-  <meta property="og:description" content="Free privacy-first vCard QR codes plus OpenAPI, MCP, markdown docs, and JSON API errors for agent integrations.">
-  <meta property="og:image" content="${SITE_URL}/vcard-qr-generator-promo.png">
-  <link rel="canonical" href="${SITE_URL}/">
-  <link rel="service-desc" href="${SITE_URL}/llms.txt" type="text/plain">
-  <link rel="service-desc" href="${SITE_URL}/openapi.json" type="application/json">
-  <link rel="alternate" href="${SITE_URL}/index.md" type="text/markdown">
-  <link rel="alternate" href="${SITE_URL}/developers/" type="text/html">
-  <link rel="alternate" href="${SITE_URL}/.well-known/agent-skills/index.json" type="application/json">
-  <link rel="mcp-server" href="${BASE_URL}/mcp">
-  <script type="application/json" id="model-context">${JSON.stringify({
-    mcpServers: [{ name: 'vcard-qr-code-generator', url: `${BASE_URL}/mcp`, transport: 'streamable_http' }],
-    tools: ['get_product_context', 'create_vcard_payload'],
-  })}</script>
-  <script>document.modelContext = { mcpServers: [{ name: 'vcard-qr-code-generator', url: '${BASE_URL}/mcp', transport: 'streamable_http' }], tools: ['get_product_context', 'create_vcard_payload'] }; try { navigator.modelContext = document.modelContext; } catch (error) {}</script>
-  <script type="application/ld+json">${JSON.stringify(homepageStructuredData())}</script>
-</head>
-<body>
-  <main>
-    <h1>vCard QR Code Generator</h1>
-    <p>vCard QR Code Generator creates privacy-first contact QR codes for business cards, digital business cards, resumes, badges, and email signatures.</p>
-    <h2>Developer API and Agent Resources</h2>
-    <p>Agents can integrate with the public REST API, OpenAPI spec, MCP server, markdown docs, JSON error contract, and sandbox-style test endpoints without requiring API keys for basic vCard payload generation.</p>
-    <ul>
-      <li><a href="${SITE_URL}/developers/">Developer portal</a></li>
-      <li><a href="${SITE_URL}/api-docs.html">vcardqrcodegenerator API docs</a></li>
-      <li><a href="${SITE_URL}/openapi.json">OpenAPI spec</a></li>
-      <li><a href="${SITE_URL}/developers/auth.html">Auth docs and API key policy</a></li>
-      <li><a href="${SITE_URL}/developers/webhooks.html">Webhooks docs</a></li>
-      <li><a href="${SITE_URL}/developers/rate-limits.html">Rate limits and deprecation policy</a></li>
-      <li><a href="${BASE_URL}/api/v1/health">API health check</a></li>
-      <li><a href="${BASE_URL}/api/v1/errors/example">JSON error response example</a></li>
-      <li><a href="${BASE_URL}/mcp">Streamable HTTP MCP endpoint</a></li>
-      <li><a href="${SITE_URL}/llms.txt">llms.txt</a></li>
-      <li><a href="${SITE_URL}/index.md">Markdown homepage fallback</a></li>
-    </ul>
-    <form hidden method="post" action="${BASE_URL}/mcp" data-mcp-server="vcard-qr-code-generator" data-mcp-transport="streamable_http" data-mcp-tool="create_vcard_payload"></form>
-    <h2>JSON Error Contract</h2>
-    <p>API errors return application/json with error.code, error.message, error.hint, error.docsUrl, and error.status so agents can recover without parsing HTML.</p>
-    <h2>Sandbox and API Keys</h2>
-    <p>The public sandbox-style endpoints do not require API keys: use GET /api/v1/health, GET /api/v1/product, GET /api/v1/templates, and POST /api/v1/vcard with sample contact data.</p>
-    <p>
-      <a href="https://nicklaunches.com/products/vcard-qr-code-generator/?utm_source=vcardqrcodegenerator.com&utm_medium=badge&utm_campaign=featured" target="_blank" rel="noopener">
-        <img src="https://nicklaunches.com/badges/featured-dark.png" alt="vCard QR Code Generator on Nick Launches" width="244" height="56">
-      </a>
-    </p>
-    <p><a href="${SITE_URL}/">Open the full browser generator</a>.</p>
-  </main>
-</body>
-</html>`;
-}
-
-async function proxyStaticPage(request, path) {
-  const response = await fetch(new Request(`${SITE_URL}${path}`, request));
-  return noTransform(response);
 }
 
 function pricingMarkdown() {
@@ -2132,16 +2068,14 @@ export default {
     }
 
     if (url.pathname === '/') {
+      if (url.hostname === 'vcardqrcodegenerator.com') {
+        return redirectToPreferredHost(url);
+      }
       if (url.searchParams.get('mode') === 'agent' || wantsMarkdown(request)) {
         return markdown(homepageMarkdown());
       }
       if (url.hostname === 'www.vcardqrcodegenerator.com') {
         return homepageHtml(request);
-      }
-      if (url.hostname === 'vcardqrcodegenerator.com') {
-        return html(agentSafeHomepageHtml(), 200, {
-          link: `<${SITE_URL}/llms.txt>; rel="service-desc"; type="text/plain", <${SITE_URL}/openapi.json>; rel="service-desc"; type="application/json", <${SITE_URL}/developers/>; rel="alternate"; type="text/html", <${SITE_URL}/index.md>; rel="alternate"; type="text/markdown", <${BASE_URL}/mcp>; rel="mcp-server"`,
-        });
       }
     }
 
@@ -2159,26 +2093,6 @@ export default {
 
     if (ROOT_MARKDOWN_DOCS[url.pathname]) {
       return markdown(ROOT_MARKDOWN_DOCS[url.pathname], 200, { 'cache-control': 'public, max-age=300, no-transform' });
-    }
-
-    if (url.hostname === 'vcardqrcodegenerator.com' && (url.pathname === '/developers' || url.pathname === '/developers/')) {
-      return proxyStaticPage(request, '/developers/');
-    }
-
-    if (url.hostname === 'vcardqrcodegenerator.com' && url.pathname.startsWith('/developers/')) {
-      return proxyStaticPage(request, url.pathname);
-    }
-
-    if (url.hostname === 'vcardqrcodegenerator.com' && (url.pathname === '/docs/api' || url.pathname === '/docs/api/')) {
-      return proxyStaticPage(request, '/docs/api/');
-    }
-
-    if (url.hostname === 'vcardqrcodegenerator.com' && url.pathname === '/api-docs.html') {
-      return proxyStaticPage(request, '/api-docs.html');
-    }
-
-    if (url.hostname === 'vcardqrcodegenerator.com' && (url.pathname === '/brand/vcardqrcodegenerator' || url.pathname === '/brand/vcardqrcodegenerator/')) {
-      return proxyStaticPage(request, '/brand/vcardqrcodegenerator/');
     }
 
     if (url.pathname === '/robots.txt') {
@@ -2228,7 +2142,7 @@ export default {
     }
 
     if (url.hostname === 'vcardqrcodegenerator.com' && url.pathname === '/sitemap.xml') {
-      return fetch(new Request(`${SITE_URL}${url.pathname}`, request));
+      return redirectToPreferredHost(url);
     }
 
     if (url.pathname === '/ads.txt') {
@@ -2346,7 +2260,7 @@ export default {
     }
 
     if (url.hostname === 'vcardqrcodegenerator.com') {
-      return Response.redirect(`${SITE_URL}${url.pathname}${url.search}`, 301);
+      return redirectToPreferredHost(url);
     }
 
     return notFound();

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,6 +5,7 @@ compatibility_date = "2024-06-20"
 routes = [
   { pattern = "api.vcardqrcodegenerator.com/*", zone_name = "vcardqrcodegenerator.com" },
   { pattern = "vcardqrcodegenerator.com/", zone_name = "vcardqrcodegenerator.com" },
+  { pattern = "vcardqrcodegenerator.com/*", zone_name = "vcardqrcodegenerator.com" },
   { pattern = "www.vcardqrcodegenerator.com/", zone_name = "vcardqrcodegenerator.com" },
   { pattern = "vcardqrcodegenerator.com/payment/verify", zone_name = "vcardqrcodegenerator.com" },
   { pattern = "www.vcardqrcodegenerator.com/payment/verify", zone_name = "vcardqrcodegenerator.com" },


### PR DESCRIPTION
## Summary
- redirect apex public paths to matching www URLs from the Worker
- remove the apex-only agent homepage shell as a normal 200 homepage
- switch sitemap and robots sitemap references to the canonical www host
- preserve dedicated MCP, well-known, API, payment, ads.txt, and robots handlers before canonical redirects

## Verification
- node --check workers/router.js
- npx wrangler deploy --dry-run
- sitemap check: 0 apex loc entries, 118 www loc entries
- local MCP initialize against Wrangler dev returned 200 JSON-RPC result

Unrelated local untracked files were not staged.